### PR TITLE
Fixes for MediaWiki 1.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Purpose: give access to some users of [Shroomok Discord Community](https://disco
 * [RestCord - Discord API](https://github.com/restcord/restcord)
 
 ## Create composer.local.json before installation
-This extension has a dependency on particular version of one package which can be installed only from github.
+This extension has a dependency on particular version of one package which can be installed only from GitHub.
 
-Thats why you need to edit (or create) a composer.local.json at the root of your wiki folder
+That's why you need to edit (or create) a composer.local.json at the root of your wiki folder
 
 ### Composer.local.json
 ```json
@@ -62,7 +62,7 @@ $wgPluggableAuth_Config['discordauth'] = [
 
 $wgDiscordAuthBotToken = '<DISCORD BOT TOKEN>';
 $wgDiscordGuildId = <YOUR DISCORD GUILD ID>; // you can copy this within Discord app interface
-$wgDiscordApprovedRoles = ['<role>']; // users only with the specified roles will be able to login
+$wgDiscordApprovedRoles = ['<role name 1>', '<role name 2>']; // users only with the specified roles will be able to login
 
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"mediawiki/oauthclient": "*",
 		"wohali/oauth2-discord-new": "^1.2",
-		"restcord/restcord": "*"
+		"restcord/restcord": "dev-develop"
 	},
 	"repositories": [
 		{

--- a/extension.json
+++ b/extension.json
@@ -46,7 +46,7 @@
 	},
 	"DiscordApprovedRoles": {
 	  "value": [],
-	  "descriptionmsg": "Array of strings. Discord users with the following roles are allowed to login to wiki"
+	  "descriptionmsg": "Array of strings. An array of Discord Role names. Discord users with the following roles are allowed to login to wiki"
 	},
 	"DiscordToRegisterNS": {
 	  "value": false,

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -19,7 +19,7 @@ class DiscordAuth extends AuthProvider {
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct( string $clientId, string $clientSecret, ?string $authUri, ?string $redirectUri ) {
+	public function __construct( string $clientId, string $clientSecret, ?string $authUri, ?string $redirectUri, array $extensionData = [] ) {
 		$this->provider = new Discord( [
 			'clientId' => $clientId,
 			'clientSecret' => $clientSecret,

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -31,7 +31,7 @@ class DiscordAuth extends AuthProvider {
 	 * @inheritDoc
 	 */
 	public function login( ?string &$key, ?string &$secret, ?string &$authUrl ): bool {
-		$authUrl = $this->provider->getAuthorizationUrl([ 'scope' => [ 'identify' ] ]);
+		$authUrl = $this->provider->getAuthorizationUrl([ 'scope' => [ 'identify', 'email' ] ]);
 
 		$secret = $this->provider->getState();
 
@@ -64,7 +64,7 @@ class DiscordAuth extends AuthProvider {
 				'name' => self::DISCORD . '-' . $user->getId(),
 				'discord_user_id' => $user->getId(),
 				'realname' => $user->getUsername(),
-				'email' => $user->getId() . '@discord.com',
+				'email' => $user->getEmail(),
 				self::SOURCE => self::DISCORD
 			];
 		} catch ( \Exception $e ) {


### PR DESCRIPTION
Hi,

Thanks for making this extension! I just got it working on my Discord server. I made some fixes below to make it work on MediaWiki 1.40. Sorry, I'm new to PHP and MediaWiki so the logging changes aren't done that well. I think it might be good to also add debug logging to other methods later on.


- Fix crash due to constructor mismatch in DiscordAuth.php
- Add some logging in DiscordAuthHooks.php for debugging
- Clarify requirement of role name instead of ID in extension.json and README.md