### PR TITLE
Additional config options and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Purpose: give access to some users of [Shroomok Discord Community](https://disco
 * [RestCord - Discord API](https://github.com/restcord/restcord)
 
 ## Create composer.local.json before installation
-This extension has a dependency on particular version of one package which can be installed only from github.
+This extension has a dependency on particular version of one package which can be installed only from GitHub.
 
-Thats why you need to edit (or create) a composer.local.json at the root of your wiki folder
+That's why you need to edit (or create) a composer.local.json at the root of your wiki folder
 
 ### Composer.local.json
 ```json
@@ -62,7 +62,7 @@ $wgPluggableAuth_Config['discordauth'] = [
 
 $wgDiscordAuthBotToken = '<DISCORD BOT TOKEN>';
 $wgDiscordGuildId = <YOUR DISCORD GUILD ID>; // you can copy this within Discord app interface
-$wgDiscordApprovedRoles = ['<role>']; // users only with the specified roles will be able to login
+$wgDiscordApprovedRoles = ['<role name 1>', '<role name 2>']; // users only with the specified roles will be able to login
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ $wgPluggableAuth_Config['discordauth'] = [
 $wgDiscordAuthBotToken = '<DISCORD BOT TOKEN>';
 $wgDiscordGuildId = <YOUR DISCORD GUILD ID>; // you can copy this within Discord app interface
 $wgDiscordApprovedRoles = ['<role name 1>', '<role name 2>']; // users only with the specified roles will be able to login
-
+$wgDiscordCollectEmail = false; // Collect the user's email from Discord and use it when creating their wiki account
+$wgPrependDiscordToWikiUsername = true; // Prepend "Discord" before usernames to distinguish them from locally created users (e.g. "Discord-User123" instead of User123)
 ```
 
 ### LocalSettings.php If you want to have a custom NS for Discord users and change Main Page layout to simplify ux

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"mediawiki/oauthclient": "*",
 		"wohali/oauth2-discord-new": "^1.2",
-		"restcord/restcord": "*"
+		"restcord/restcord": "dev-develop"
 	},
 	"repositories": [
 		{

--- a/extension.json
+++ b/extension.json
@@ -48,6 +48,14 @@
 	  "value": [],
 	  "descriptionmsg": "Array of strings. An array of Discord Role names. Discord users with the following roles are allowed to login to wiki"
 	},
+    "DiscordCollectEmail": {
+	  "value": false,
+	  "descriptionmsg": "Boolean. This flag regulates whether the user's Discord email should be collected and used to create their wiki account"
+	},
+    "PrependDiscordToWikiUsername": {
+	  "value": true,
+      "descriptionmsg": "Boolean. This flag regulates whether \"Discord\" should be prepended to their wiki username to distinguish them from locally created users"
+    },
 	"DiscordToRegisterNS": {
 	  "value": false,
 	  "descriptionmsg": "This flag regulates whether to run onMediaWikiServices hook or not which registers Discord NS, group, and permissions"

--- a/extension.json
+++ b/extension.json
@@ -46,7 +46,7 @@
 	},
 	"DiscordApprovedRoles": {
 	  "value": [],
-	  "descriptionmsg": "Array of strings. Discord users with the following roles are allowed to login to wiki"
+	  "descriptionmsg": "Array of strings. An array of Discord Role names. Discord users with the following roles are allowed to login to wiki"
 	},
 	"DiscordToRegisterNS": {
 	  "value": false,

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -71,13 +71,18 @@ class DiscordAuth extends AuthProvider {
 		try {
 			$token = $this->provider->getAccessToken('authorization_code', ['code' => $_GET['code']]);
 			$user = $this->provider->getResourceOwner($token);
-			return [
+			$userInfo = [
 				'name' => self::DISCORD . '-' . $user->getId(),
 				'discord_user_id' => $user->getId(),
 				'realname' => $user->getUsername(),
-				'email' => $this->collectEmail ? $user->getEmail() : '',
 				self::SOURCE => self::DISCORD
 			];
+
+			if ( $this->collectEmail ) {
+				$userInfo[] = ['email' => $user->getEmail()];
+			}
+
+			return $userInfo;
 		} catch ( \Exception $e ) {
 			$errorMessage = $e->getMessage();
 			return false;

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -17,7 +17,6 @@ class DiscordAuth extends AuthProvider {
 	 */
 	private $provider;
 	private $collectEmail;
-	private $prependDiscordToUsername;
 
 	/**
 	 * @inheritDoc
@@ -30,7 +29,6 @@ class DiscordAuth extends AuthProvider {
 		] );
 		$config = MediaWikiServices::getInstance()->getMainConfig();
 		$this->collectEmail = (bool)$config->get('DiscordCollectEmail');
-		$this->prependDiscordToUsername = (bool)$config->get('PrependDiscordToWikiUsername');
 	}
 
 	/**
@@ -73,11 +71,10 @@ class DiscordAuth extends AuthProvider {
 		try {
 			$token = $this->provider->getAccessToken('authorization_code', ['code' => $_GET['code']]);
 			$user = $this->provider->getResourceOwner($token);
-			$username = $this->prependDiscordToUsername ? self::DISCORD . '-' . $user->getUsername() : $user->getUsername();
 			return [
-				'name' => $username,
+				'name' => self::DISCORD . '-' . $user->getId(),
 				'discord_user_id' => $user->getId(),
-				'realname' => $username,
+				'realname' => $user->getUsername(),
 				'email' => $this->collectEmail ? $user->getEmail() : '',
 				self::SOURCE => self::DISCORD
 			];

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -19,7 +19,7 @@ class DiscordAuth extends AuthProvider {
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct( string $clientId, string $clientSecret, ?string $authUri, ?string $redirectUri ) {
+	public function __construct( string $clientId, string $clientSecret, ?string $authUri, ?string $redirectUri, array $extensionData = [] ) {
 		$this->provider = new Discord( [
 			'clientId' => $clientId,
 			'clientSecret' => $clientSecret,

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -31,7 +31,7 @@ class DiscordAuth extends AuthProvider {
 	 * @inheritDoc
 	 */
 	public function login( ?string &$key, ?string &$secret, ?string &$authUrl ): bool {
-		$authUrl = $this->provider->getAuthorizationUrl([ 'scope' => [ 'identify' ] ]);
+		$authUrl = $this->provider->getAuthorizationUrl([ 'scope' => [ 'identify', 'email' ] ]);
 
 		$secret = $this->provider->getState();
 
@@ -64,7 +64,7 @@ class DiscordAuth extends AuthProvider {
 				'name' => self::DISCORD . '-' . $user->getId(),
 				'discord_user_id' => $user->getId(),
 				'realname' => $user->getUsername(),
-				'email' => $user->getId() . '@discord.com',
+				'email' => $user->getEmail(),
 				self::SOURCE => self::DISCORD
 			];
 		} catch ( \Exception $e ) {

--- a/src/DiscordAuthHooks.php
+++ b/src/DiscordAuthHooks.php
@@ -148,7 +148,6 @@ class DiscordAuthHooks {
 	 */
 	public function onWSOAuthAfterGetUser( &$user_info, &$errorMessage ): bool {
 		if ( !$user_info ) {
-		    $errorMessage = 'Failed to get user info';
 			return false;
 		}
 		if ( !isset( $user_info[DiscordAuth::SOURCE] )) {

--- a/src/DiscordAuthHooks.php
+++ b/src/DiscordAuthHooks.php
@@ -178,16 +178,18 @@ class DiscordAuthHooks {
 			return false;
 		}
 
-		$dbr = wfGetDB( DB_MASTER );
-        $user = $dbr->select(
-            'user',
-            ['user_name'],
-            ['user_email' => $user_info['email']],
-            __METHOD__
-        )->fetchObject();
+		if ( $this->config->get('DiscordCollectEmail') === true ) {
+			$dbr = wfGetDB( DB_MASTER );
+			$user = $dbr->select(
+				'user',
+				['user_name'],
+				['user_email' => $user_info['email']],
+				__METHOD__
+			)->fetchObject();
 
-		if ( $user ) {
-			$user_info['name'] = $user->user_name;
+			if ( $user ) {
+				$user_info['name'] = $user->user_name;
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Add email and username options as well as error messages
- Make providing email optional depending on config
- Make prepending "Discord" to username optional depending on config
- Use Discord username instead of numeric ID for wiki username
- Add error messages for authentication failures