### PR TITLE
Uniform config names

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -40,31 +40,31 @@
 	  "value": false,
 	  "descriptionmsg": "String. Discord bot token"
 	},
-	"DiscordGuildId": {
+	"DiscordAuthGuildId": {
 	  "value": false,
 	  "descriptionmsg": "Integer. Guild (server) id of your Discord Community"
 	},
-	"DiscordApprovedRoles": {
+	"DiscordAuthApprovedRoles": {
 	  "value": [],
 	  "descriptionmsg": "Array of strings. An array of Discord Role names. Discord users with the following roles are allowed to login to wiki"
 	},
-    "DiscordCollectEmail": {
+    "DiscordAuthCollectEmail": {
 	  "value": false,
 	  "descriptionmsg": "Boolean. This flag regulates whether the user's Discord email should be collected and used to create their wiki account"
 	},
-    "PrependDiscordToWikiUsername": {
+    "DiscordAuthPrependDiscordToWikiUsername": {
 	  "value": true,
       "descriptionmsg": "Boolean. This flag regulates whether \"Discord\" should be prepended to their wiki username to distinguish them from locally created users"
     },
-	"DiscordToRegisterNS": {
+	"DiscordAuthRegisterNS": {
 	  "value": false,
 	  "descriptionmsg": "This flag regulates whether to run onMediaWikiServices hook or not which registers Discord NS, group, and permissions"
 	},
-	"DiscordNS": {
+	"DiscordAuthNS": {
 	  "value": false,
 	  "descriptionmsg": "Discord NS object, for instance { \"id\": 4000, \"alias\": \"Discord\" }"
 	},
-	"DiscordShowUserContributionsOnMainPage": {
+	"DiscordAuthShowUserContributionsOnMainPage": {
 	  "value": false,
 	  "descriptionmsg": "Change main page to make it easier for navigation and writing new articles for Discord user"
 	}

--- a/src/AuthenticationProvider/DiscordAuth.php
+++ b/src/AuthenticationProvider/DiscordAuth.php
@@ -28,7 +28,7 @@ class DiscordAuth extends AuthProvider {
 			'redirectUri' => $redirectUri
 		] );
 		$config = MediaWikiServices::getInstance()->getMainConfig();
-		$this->collectEmail = (bool)$config->get('DiscordCollectEmail');
+		$this->collectEmail = (bool)$config->get('DiscordAuthCollectEmail');
 	}
 
 	/**

--- a/src/DiscordAuthHooks.php
+++ b/src/DiscordAuthHooks.php
@@ -178,7 +178,7 @@ class DiscordAuthHooks {
 
 		$userApproved = false;
 		try {
-			$userApproved = $this->checkDiscordUser( $user_info['discord_user_id'], $this->guildId, $this->config->get('DiscordApprovedRoles') );
+			$userApproved = $this->checkDiscordUser( $user_info['discord_user_id'], $this->guildId, $this->approvedRoles );
 		} catch ( \Exception $e ) {
 		    $errorMessage = $e->getMessage();
 			return false;

--- a/src/DiscordAuthHooks.php
+++ b/src/DiscordAuthHooks.php
@@ -17,17 +17,26 @@ use DiscordAuth\AuthenticationProvider\DiscordAuth;
 use MediaWiki\Logger\LoggerFactory;
 
 class DiscordAuthHooks {
-
-	protected $discordClient;
-	protected $guildId;
-	protected $config;
 	protected $logger;
+	private $discordClient;
+	protected $config;
+	protected int $guildId;
+	protected array $approvedRoles;
+	protected bool $collectEmail;
+	protected bool $showUserContributionsOnMainPage;
+	protected bool $registerNS;
+	protected string $NS;
 
 	public function __construct() {
 		/** @var DiscordClient $discordClient */
 		$this->discordClient = MediaWikiServices::getInstance()->get('DiscordClient');
 		$this->config = MediaWikiServices::getInstance()->getMainConfig();
-		$this->guildId = $this->config->get('DiscordGuildId');
+		$this->guildId = $this->config->get('DiscordAuthGuildId');
+		$this->approvedRoles = $this->config->get('DiscordAuthApprovedRoles');
+		$this->collectEmail = $this->config->get('DiscordAuthCollectEmail');
+		$this->showUserContributionsOnMainPage = $this->config->get('DiscordAuthShowUserContributionsOnMainPage');
+		$this->registerNS = $this->config->get('DiscordAuthRegisterNS');
+		$this->NS = $this->config->get('DiscordAuthNS');
 		// Accessing this in checkDiscordUser returns null for some reason?
         $this->logger = LoggerFactory::getInstance( 'DiscordAuth' );
 	}
@@ -45,11 +54,11 @@ class DiscordAuthHooks {
 	 * @throws \MWException
 	 */
 	public function onOutputPageBeforeHTML( \OutputPage $out, &$text ) {
-		if ( $this->config->get('DiscordShowUserContributionsOnMainPage') !== true ) {
+		if ( $this->showUserContributionsOnMainPage !== true ) {
 			return;
 		}
 
-		if ( $this->config->get('DiscordToRegisterNS') !== true ) {
+		if ( $this->registerNS !== true ) {
 			return;
 		}
 
@@ -57,7 +66,7 @@ class DiscordAuthHooks {
 			return;
 		}
 
-		if ( !$ns = self::getDiscordNS($this->config->get('DiscordNS')) ) {
+		if ( !$ns = self::getDiscordNS($this->NS) ) {
 			return;
 		}
 
@@ -113,11 +122,11 @@ class DiscordAuthHooks {
 			   $wgOAuthAutoPopulateGroups, $wgExtraNamespaces;
 
 		$config = $services->getMainConfig();
-		if ( $config->get('DiscordToRegisterNS') !== true ) {
+		if ( $config->get('DiscordAuthRegisterNS') !== true ) {
 			return;
 		}
 
-		if (!$ns = self::getDiscordNS($config->get('DiscordNS'))) {
+		if (!$ns = self::getDiscordNS($config->get('DiscordAuthNS'))) {
 			return;
 		}
 		if ( array_key_exists( $ns['id'], $wgExtraNamespaces ) ) {
@@ -162,7 +171,7 @@ class DiscordAuthHooks {
 		    $errorMessage = 'No guild configured';
 		    return false;
 		}
-        if ( $this->config->get('DiscordApprovedRoles') === null ) {
+        if ( $this->approvedRoles === [] ) {
             $errorMessage = 'No approved roles configured';
             return false;
         }
@@ -178,7 +187,7 @@ class DiscordAuthHooks {
 			return false;
 		}
 
-		if ( $this->config->get('DiscordCollectEmail') === true ) {
+		if ( $this->collectEmail === true ) {
 			$dbr = wfGetDB( DB_MASTER );
 			$user = $dbr->select(
 				'user',
@@ -203,20 +212,20 @@ class DiscordAuthHooks {
 	 * @throws \Psr\Container\NotFoundExceptionInterface
 	 */
 	protected function checkDiscordUser(string $discordUserId, int $discordGuildId, array $approvedRoleNames ) {
-		LoggerFactory::getInstance( 'DiscordAuth' )->debug("Checking User {$discordUserId}");
+		$this->logger->debug("Checking User {$discordUserId}");
 		$member = $this->discordClient->guild->getGuildMember(
 			['guild.id' => $discordGuildId, 'user.id' => (int) $discordUserId]
 		);
 
 		$memberRolesJson = json_encode($member->roles);
-		LoggerFactory::getInstance( 'DiscordAuth' )->debug("Member has roles {$memberRolesJson}");
+		$this->logger->debug("Member has roles {$memberRolesJson}");
 
 		$roleIds = $this->getApprovedDiscordRolesIdsByNames( $discordGuildId, $approvedRoleNames );
 		$roleIdsJson = json_encode($roleIds);
-		LoggerFactory::getInstance( 'DiscordAuth' )->debug("Found approved role list: {$roleIdsJson}");
+		$this->logger->debug("Found approved role list: {$roleIdsJson}");
 
 		if ( !$roleIds ) {
-			LoggerFactory::getInstance( 'DiscordAuth' )->error('No approved Discord role IDs were found. Please check that role names are spelled correctly.');
+			$this->logger->error('No approved Discord role IDs were found. Please check that role names are spelled correctly.');
 			return false;
 		}
 
@@ -226,7 +235,7 @@ class DiscordAuthHooks {
 			}
 		}
 
-        LoggerFactory::getInstance( 'DiscordAuth' )->error('Login failed: member does not have any approved roles');
+		$this->logger->error('Login failed: member does not have any approved roles');
 		return false;
 	}
 


### PR DESCRIPTION
Add DiscordAuth prefix to names of all config properties

This is a breaking change. Please check if I missed any.