### PR TITLE
Fix VisualEditor file uploading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
 	"require": {
 		"mediawiki/oauthclient": "*",
 		"wohali/oauth2-discord-new": "^1.2",
-		"restcord/restcord": "dev-develop"
+		"restcord/restcord": "dev-develop",
+		"psr/http-message": "1.0.1"
 	},
 	"repositories": [
 		{


### PR DESCRIPTION
`wohali/oauth2-client` has a `psr/http-message` dependency which conflicts with MediaWiki.

Downgrades PSR HTTP Message to v1.0.1, the version MediaWiki uses. Newer versions are not compatible with MediaWiki and cause errors, notably breaking file uploads in VisualEditor.

```
wohali/oauth2-discord-new 1.2.1 Discord OAuth 2.0 Client Provider for The PHP League OAuth2-Client
├──ext-json *
├──league/oauth2-client ^2.0
│  ├──guzzlehttp/guzzle ^6.0 || ^7.0
│  │  ├──ext-json *
│  │  ├──guzzlehttp/promises ^1.5.3 || ^2.0
│  │  │  └──php ^7.2.5 || ^8.0
│  │  ├──guzzlehttp/psr7 ^1.9.1 || ^2.4.5
│  │  │  ├──php ^7.2.5 || ^8.0
│  │  │  ├──psr/http-factory ^1.0
│  │  │  │  ├──php >=7.0.0
│  │  │  │  └──psr/http-message ^1.0 || ^2.0
│  │  │  │     └──php ^7.2 || ^8.0
│  │  │  ├──psr/http-message ^1.1 || ^2.0
│  │  │  │  └──php ^7.2 || ^8.0
│  │  │  └──ralouphie/getallheaders ^3.0
│  │  │     └──php >=5.6
│  │  ├──php ^7.2.5 || ^8.0
│  │  ├──psr/http-client ^1.0
│  │  │  ├──php ^7.0 || ^8.0
│  │  │  └──psr/http-message ^1.0 || ^2.0
│  │  │     └──php ^7.2 || ^8.0
│  │  └──symfony/deprecation-contracts ^2.2 || ^3.0
│  │     └──php >=8.1
│  ├──paragonie/random_compat ^1 || ^2 || ^9.99
│  │  └──php >= 7
│  └──php ^5.6 || ^7.0 || ^8.0
└──php ^7.2|^8.0
```